### PR TITLE
`p` and `logp` are just arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 Quantifying tensions between datasets.
 
 $$ \log{S} = \log{R} - \log{I} $$
+
+## Homepage
+<https://github.com/adamormondroyd/flexknot>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "suspiciousness"
-version = "0.1.0"
+version = "0.1.1"
 description = "Quantifying tensions between datasets."
 authors = [{name="Adam Neil Ormondroyd", email="Adam.Ormondroyd@gmail.com"}]
 readme = "README.md"

--- a/suspiciousness/__init__.py
+++ b/suspiciousness/__init__.py
@@ -17,9 +17,9 @@ anesthetic.NestedSamples.stats (which is required to for the calculation),
 or anesthetic.NestedSamples (which is turned into stats),
 or even just a string label + the additional chains argument.
 
-a = ac.read_chains("chains/uniform/act/act_polychord_raw/act")
-b = ac.read_chains("chains/uniform/bao/bao_polychord_raw/bao")
-ab = ac.read_chains("chains/uniform/actbao/actbao_polychord_raw/actbao")
+a = ac.read_chains("chains/uniform/act/act")
+b = ac.read_chains("chains/uniform/bao/bao")
+ab = ac.read_chains("chains/uniform/actbao/actbao")
 
 astats = a.stats()
 bstats = b.stats()

--- a/suspiciousness/core.py
+++ b/suspiciousness/core.py
@@ -120,11 +120,10 @@ def logp(a, b, ab, show=False):
 
     Returns
     -------
-    logp: anesthetic.samples.WeightedLabelledSeries
+    logp: np.ndarray
     """
     _d = d(a, b, ab)
     logp = chi2.logsf(_d-2*logS(a, b, ab), _d)
-    logp.name = r"$\log{p}$"
     if show:
         print(f"logp = {logp.mean()} ± {logp.std()}")
     return logp
@@ -146,11 +145,10 @@ def p(a, b, ab, show=False):
 
     Returns
     -------
-    p: anesthetic.samples.WeightedLabelledSeries
+    p: np.ndarray
     """
     _d = d(a, b, ab)
     p = chi2.sf(_d-2*logS(a, b, ab), _d)
-    p.name = r"$p$"
     if show:
         print(f"p = {p.mean()} ± {p.std()}")
     return p

--- a/suspiciousness/correlated.py
+++ b/suspiciousness/correlated.py
@@ -119,11 +119,10 @@ def logp(h1, h0, show=False):
 
     Returns
     -------
-    logp: anesthetic.samples.WeightedLabelledSeries
+    logp: np.ndarray
     """
     _d = d(h1, h0)
     logp = chi2.logsf(_d-2*logS(h1, h0), _d)
-    logp.name = r"$\log{p}$"
     if show:
         print(f"logp = {logp.mean()} ± {logp.std()}")
     return logp
@@ -144,11 +143,10 @@ def p(h1, h0, show=False):
 
     Returns
     -------
-    p: anesthetic.samples.WeightedLabelledSeries
+    p: np.ndarray
     """
     _d = d(h1, h0)
     p = chi2.sf(_d-2*logS(h1, h0), _d)
-    p.name = r"$p$"
     if show:
         print(f"p = {p.mean()} ± {p.std()}")
     return p

--- a/suspiciousness/utils.py
+++ b/suspiciousness/utils.py
@@ -6,8 +6,10 @@ import anesthetic as ac
 def read_cobaya_chains(chains, name):
     """
     Read a PolyChord cobaya chain, and add S8 if it is not already present.
+
+    Assumes chains are named chains/name/name.
     """
-    ns = ac.read_chains(f"{chains}/{name}/{name}_polychord_raw/{name}")
+    ns = ac.read_chains(f"{chains}/{name}/{name}")
     if 'S8' not in ns and 'sigma8' in ns and 'omegam' in ns:
         ns['S8'] = ns.sigma8 * np.sqrt(ns.omegam / 0.3)
         ns.set_label('S8', '$S_8$')


### PR DESCRIPTION
$p$ and $\log p$ are just arrays, so cannot set their names.

Also changed the convenience function to reflect that I have move the chains out of `[]_polychord_raw` to avoid confusion